### PR TITLE
Incorporate BM25 score in the results

### DIFF
--- a/libs/langchain-community/src/retrievers/bm25.ts
+++ b/libs/langchain-community/src/retrievers/bm25.ts
@@ -53,6 +53,13 @@ export class BM25Retriever extends BaseRetriever {
 
     scoredDocs.sort((a, b) => b.score - a.score);
 
-    return scoredDocs.slice(0, this.k).map((item) => item.document);
+    return scoredDocs.slice(0, this.k).map((item) => new Document({
+      ...item.document.id && { id: item.document.id },
+      pageContent: item.document.pageContent,
+      metadata: {
+        score: item.score,
+        ...item.document.metadata,
+      }
+    }));
   }
 }


### PR DESCRIPTION
In the BM25Retriever, include the score in each document's metadata.

The score is useful for performing reranking, combining BM25 with other algorithms.